### PR TITLE
View Position math + undo support

### DIFF
--- a/main.cs
+++ b/main.cs
@@ -314,8 +314,9 @@ public class VRC_Avatar_AutoScaler : EditorWindow
 
         VRCAvatarDescriptor avatar = gameObject.GetComponent<VRCAvatarDescriptor>();
         Vector3 newViewPosition = avatar.ViewPosition;
-        newViewPosition.y = newViewPosition.y * scaleAmount; // height
-        newViewPosition.z = newViewPosition.z * scaleAmount; // depth
+        newViewPosition.x = (newViewPosition.x * scaleAmount) / currentScale.x; // asymmetric view position?
+        newViewPosition.y = (newViewPosition.y * scaleAmount) / currentScale.y; // height
+        newViewPosition.z = (newViewPosition.z * scaleAmount) / currentScale.z; // depth
 
         avatar.ViewPosition = newViewPosition;
     }

--- a/main.cs
+++ b/main.cs
@@ -296,6 +296,8 @@ public class VRC_Avatar_AutoScaler : EditorWindow
             NameAvatarGameObject(clonedGameObject, autoScalerInput.scaleAmount);
 
             ScaleAvatar(clonedGameObject, autoScalerInput.scaleAmount);
+
+			Undo.RegisterCreatedObjectUndo(clonedGameObject, "VRC Avatar AutoScaler");
         });
 
         Debug.Log("Created scaled avatars");


### PR DESCRIPTION
recently wrote a tool to do similar myself before being pointed to your tool only to find it was already done, very glad to see there's a gui option (since mine uses a predefined csv)

here are a few fixes from my experience writing my own for your tool:
- noticed that the view position scaling here would not work for avatars that do not come in scale 1 1 1 (for example the izanagiroo collie at scale 1 1 1 is 81m tall)
- added registering creation of each clone to the undo history so a quick ctrl+z can be used